### PR TITLE
Disable publish-unstable workflow

### DIFF
--- a/.github/workflows/publish-unstable.yml
+++ b/.github/workflows/publish-unstable.yml
@@ -17,26 +17,26 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Install Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16.x
-          cache: yarn
-          # This creates an .npmrc that reads the NODE_AUTH_TOKEN environment variable
-          registry-url: 'https://registry.npmjs.org'
+#       - name: Install Node
+#         uses: actions/setup-node@v3
+#         with:
+#           node-version: 16.x
+#           cache: yarn
+#           # This creates an .npmrc that reads the NODE_AUTH_TOKEN environment variable
+#           registry-url: 'https://registry.npmjs.org'
 
-      - name: Install Dependencies
-        run: yarn install --frozen-lockfile
+#       - name: Install Dependencies
+#         run: yarn install --frozen-lockfile
 
-      # We need a workspace aware version of npm because our addon is in a subdir but our .npmrc is in the root
-      - name: npm8
-        run: npm install -g npm@8
+#       # We need a workspace aware version of npm because our addon is in a subdir but our .npmrc is in the root
+#       - name: npm8
+#         run: npm install -g npm@8
 
-      - name: set version
-        run: npm version --no-git-tag-version --workspaces-update=false `node -e "console.log(require('./package.json').version)"`-unstable.`git rev-parse --short HEAD`
-        working-directory: ember-simple-track-helper
+#       - name: set version
+#         run: npm version --no-git-tag-version --workspaces-update=false `node -e "console.log(require('./package.json').version)"`-unstable.`git rev-parse --short HEAD`
+#         working-directory: ember-simple-track-helper
 
-      - name: npm publish
-        run: npm publish --tag=unstable --verbose --workspace=ember-simple-track-helper
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+#       - name: npm publish
+#         run: npm publish --tag=unstable --verbose --workspace=ember-simple-track-helper
+#         env:
+#           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}


### PR DESCRIPTION
to not pollute npm versions. next step would be to integrate https://github.com/kategengler/put-built-npm-package-contents-on-branch, like it was done in https://github.com/NullVoxPopuli/ember-resources/pull/771